### PR TITLE
feat: Add uid preserve support, compile warning, error fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,10 @@
     "files.associations": {
         "bbcp_FileSpec.C": "cpp",
         "bbcp_FileSystem.C": "cpp",
-        "bbcp_FS_Unix.C": "cpp"
+        "bbcp_FS_Unix.C": "cpp",
+        "bbcp_ChkSum.C": "cpp",
+        "bbcp_Config.C": "cpp",
+        "bbcp_MD5.C": "cpp",
+        "bbcp_MD5_openssl.C": "cpp"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "files.associations": {
+        "bbcp_FileSpec.C": "cpp",
+        "bbcp_FileSystem.C": "cpp",
+        "bbcp_FS_Unix.C": "cpp"
+    }
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -154,7 +154,7 @@ OBJECT =      \
      $(OBJDIR)/bbcp_ZCX.o \
      $(OBJDIR)/NetLogger.o
 
-TARGET  = $(BINDIR)/bbcp
+TARGET  = $(BINDIR)/fmbbcp
 
 
 all:

--- a/src/bbcp_Config.C
+++ b/src/bbcp_Config.C
@@ -35,7 +35,7 @@
    AIX: -D_THREAD_SAFE
    SUN: -D_REENTRANT
 */
-  
+
 #include <unistd.h>
 #include <ctype.h>
 #include <errno.h>
@@ -147,12 +147,10 @@ bbcp_Config::bbcp_Config()
    Complvl   = 1;
    Progint   = 0;
    RWBsz     = 0;
-// SrcXeq    = strdup("ssh -x -a -oFallBackToRsh=no -oServerAliveInterval=10 "
    SrcXeq    = strdup("ssh -x -a -oFallBackToRsh=no "
-                      "%4 %I -l %U %H bbcp");
-// SnkXeq    = strdup("ssh -x -a -oFallBackToRsh=no -oServerAliveInterval=10 "
+                      "%4 %I -l %U %H fmbbcp");
    SnkXeq    = strdup("ssh -x -a -oFallBackToRsh=no "
-                      "%4 %I -l %U %H bbcp");
+                      "%4 %I -l %U %H fmbbcp");
    Logurl    = 0;
    Logfn     = 0;
    MLog      = 0;
@@ -243,6 +241,8 @@ bbcp_Config::~bbcp_Config()
 #define Hmsg1(a)   {bbcp_Fmsg("Config", a);    help(1);}
 #define Hmsg2(a,b) {bbcp_Fmsg("Config", a, b); help(1);}
 
+/******************************************************************************/
+/*                            A r g u m e n t s                              */
 /******************************************************************************/
 
 void bbcp_Config::Arguments(int argc, char **argv, int cfgfd)
@@ -423,8 +423,8 @@ void bbcp_Config::Arguments(int argc, char **argv, int cfgfd)
                       if (!strcmp("d", arglist.argval)) Options |= bbcp_FSYNC;
                  else if (!strcmp("dd",arglist.argval)) Options |= bbcp_DSYNC;
                  else{bbcp_Fmsg("Config","Invalid sync option -",arglist.argval);
-                      Cleanup(1, argv[0], cfgfd);
-                     }
+                    Cleanup(1, argv[0], cfgfd);
+                 }
                  SynSpec = strdup(arglist.argval);
                  break;
        case 'z': Options |= bbcp_CON2SRC;
@@ -737,7 +737,7 @@ H("        i -> input pipe or program, o -> output pipe or program")
 H("-s snum number of network streams to use (default is 4).")
 H("-o      enforces output ordering (writes in ascending offset order).")
 H("-O      omits files that already exist at the target node (useful with -r).")
-H("-p      preserve source mode, ownership, and dates.")
+H("-p      preserve source mode, ownership (UID and GID), and dates.")
 H("-P sec  produce a progress message every sec seconds (15 sec minimum).")
 H("-q lvl  specifies the quality of service for routers that support QOS.")
 H("-r      copy subdirectories and their contents (actual files only).")
@@ -874,7 +874,7 @@ int bbcp_Config::Configure(const char *cfgFN)
 /******************************************************************************/
 /*                               D i s p l a y                                */
 /******************************************************************************/
-  
+
 void bbcp_Config::Display()
 {
 

--- a/src/bbcp_FS_Null.h
+++ b/src/bbcp_FS_Null.h
@@ -54,6 +54,8 @@ int        RM(const char *path) {return 0;}
 
 int        setGroup(const char *path, const char *Group) {return 0;}
 
+int        setUser(const char *path, const char *User) {return 0;}
+
 int        setMode(const char *path, mode_t mode) {return 0;}
 
 int        setTimes(const char *path, time_t atime, time_t mtime) {return 0;}

--- a/src/bbcp_FS_Pipe.h
+++ b/src/bbcp_FS_Pipe.h
@@ -53,6 +53,8 @@ int        RM(const char *path) {return 0;}
 
 int        setGroup(const char *path, const char *Group) {return 0;}
 
+int        setUser(const char *path, const char *User) {return 0;}
+
 int        setMode(const char *path, mode_t mode) {return 0;}
 
 int        setTimes(const char *path, time_t atime, time_t mtime) {return 0;}

--- a/src/bbcp_FS_Unix.C
+++ b/src/bbcp_FS_Unix.C
@@ -70,7 +70,7 @@
 /******************************************************************************/
 
 extern bbcp_System bbcp_OS;
-  
+
 /******************************************************************************/
 /*                            A p p l i c a b l e                             */
 /******************************************************************************/
@@ -276,6 +276,25 @@ int bbcp_FS_Unix::setGroup(const char *path, const char *Group)
 }
 
 /******************************************************************************/
+/*                              s e t U s e r                                */
+/******************************************************************************/
+  
+int bbcp_FS_Unix::setUser(const char *path, const char *User)
+{
+    uid_t uid;
+
+// Convert the user name to a uid
+//
+   if (!User || !User[0]) return 0;
+   uid = bbcp_OS.getUID(User);
+
+// Set the user code and return
+//
+   if (chown(path, uid, (gid_t)-1)) return -errno;
+   return 0;
+}
+
+/******************************************************************************/
 /*                               s e t M o d e                                */
 /******************************************************************************/
   
@@ -387,6 +406,11 @@ int bbcp_FS_Unix::Stat(struct stat &xbuff, bbcp_FileInfo *sbuff)
 //
    if (sbuff->Group) free(sbuff->Group);
    sbuff->Group = bbcp_OS.getGNM(xbuff.st_gid);
+
+// Convert uid to a user name
+//
+   if (sbuff->User) free(sbuff->User);
+   sbuff->User = bbcp_OS.getUNM(xbuff.st_uid);
 
 // All done
 //

--- a/src/bbcp_FS_Unix.h
+++ b/src/bbcp_FS_Unix.h
@@ -57,6 +57,8 @@ int        RM(const char *path);
 
 int        setGroup(const char *path, const char *Group);
 
+int        setUser(const char *path, const char *User);
+
 int        setMode(const char *path, mode_t mode);
 
 int        setTimes(const char *path, time_t atime, time_t mtime);

--- a/src/bbcp_FileSpec.C
+++ b/src/bbcp_FileSpec.C
@@ -340,7 +340,7 @@ int bbcp_FileSpec::Encode(char *buff, size_t blen)
 // operation.
 //
    if ((Space = index(filename, ' ')))
-      {filereqn = fspec2 = strdup(filename); Otype &= UprCase;
+      {filereqn = fspec2 = strdup(filename); Info.Otype &= UprCase;
        Space = filereqn + (Space - filename);
        do {*Space = SpaceAlt;} while((Space = index(Space+1, ' ')));
       }
@@ -348,7 +348,7 @@ int bbcp_FileSpec::Encode(char *buff, size_t blen)
 // If we have symlink data then we need to encode spaces there as well
 //
    if (isSL && (Space = index(Info.SLink, ' ')))
-      {Otype &= UprCase;
+      {Info.Otype &= UprCase;
        do {*Space = SpaceAlt;} while((Space = index(Space+1, ' ')));
       }
 
@@ -377,7 +377,7 @@ int bbcp_FileSpec::Encode(char *buff, size_t blen)
 
 // Format the specification
 //
-   n = snprintf(buff, blen, bbcp_ENFMT, seqno, Otype, Info.fileid,
+   n = snprintf(buff, blen, bbcp_ENFMT, seqno, Info.Otype, Info.fileid,
                 Info.mode, theSize, Info.atime, Info.mtime, theGrp,
                 filereqn, theUsr, slSep, slXeq);
 

--- a/src/bbcp_FileSpec.C
+++ b/src/bbcp_FileSpec.C
@@ -623,6 +623,11 @@ int bbcp_FileSpec::setStat(mode_t Mode)
    if (!(bbcp_Cfg.Options & bbcp_PTONLY) && Info.Group)
       FSp->setGroup (targpath, Info.Group);
 
+// Set the user only if this is a plain preserve
+//
+   if (!(bbcp_Cfg.Options & bbcp_PTONLY) && Info.User)
+      FSp->setUser (targpath, Info.User);
+
 // Check if any errors occured (we ignore these just like cp/scp does)
 //
    if (act) bbcp_Emsg("setStat", -retc, act, targpath);

--- a/src/bbcp_FileSpec.C
+++ b/src/bbcp_FileSpec.C
@@ -53,9 +53,9 @@ extern bbcp_Config   bbcp_Cfg;
 /*                     L o c a l   D e f i n i t i o n s                      */
 /******************************************************************************/
 
-// <seqno> <fnode> <inode> <mode> <size> <acctime> <modtime> <group> <fname>
+// <seqno> <fnode> <inode> <mode> <size> <acctime> <modtime> <group> <user> <fname>
 //
-#define bbcp_ENFMT "%d %c %lld %o %lld %lx %lx %s %s %s%s%s\n"
+#define bbcp_ENFMT "%d %c %lld %o %lld %lx %lx %s %s %s %s%s\n"
 #define bbcp_DEFMT "%d %c %lld %o %lld %lx %lx %31s %31s %2054s"
 #define bbcp_DEGMT "%d %c %Ld  %o %Ld  %lx %lx %31s %31s %2054s"
 
@@ -265,20 +265,20 @@ int bbcp_FileSpec::Create_Path()
 int bbcp_FileSpec::Decode(char *buff, char *xName)
 {
    static const char LwrCase = 0x20;
-   char gnbuff[64], *Space;
+   char gnbuff[64], unbuff[64], *Space;
    char fnbuff[2056], *fmt = (char *)bbcp_DEFMT;
    int xtry=1, n;
 
 // Decode the specification
 //
    do {n = sscanf(buff, fmt, &seqno, &Info.Otype, &Info.fileid, &Info.mode,
-                  &Info.size, &Info.atime, &Info.mtime, gnbuff, fnbuff);
+                  &Info.size, &Info.atime, &Info.mtime, gnbuff, unbuff, fnbuff);
        fmt = (char *)bbcp_DEGMT;
-      } while(xtry-- && n != 9);
+      } while(xtry-- && n != 10);
 
 // Make sure it is correct
 //
-   if (n != 9) 
+   if (n != 10) 
       {sprintf(fnbuff,"Unable to decode item %d in file specification from",n+1);
        return bbcp_Fmsg("Decode", fnbuff, (xName ? xName : hostname));
       }
@@ -300,9 +300,9 @@ int bbcp_FileSpec::Decode(char *buff, char *xName)
 //
    while((Space = index(Info.Group, SpaceAlt))) *Space++ = ' ';
 
-   // Handle user name similarly to group name
+   // Handle user name
    if (Info.User) free(Info.User);
-   Info.User = strdup(gnbuff);
+   Info.User = strdup(unbuff);
    Space = Info.User;
    while((Space = index(Space, SpaceAlt))) *Space++ = ' ';
 
@@ -379,7 +379,7 @@ int bbcp_FileSpec::Encode(char *buff, size_t blen)
 //
    n = snprintf(buff, blen, bbcp_ENFMT, seqno, Info.Otype, Info.fileid,
                 Info.mode, theSize, Info.atime, Info.mtime, theGrp,
-                filereqn, theUsr, slSep, slXeq);
+                theUsr, filereqn, slSep, slXeq);
 
 // Make sure all went well
 //

--- a/src/bbcp_FileSystem.h
+++ b/src/bbcp_FileSystem.h
@@ -42,12 +42,14 @@ struct bbcp_FileInfo
        time_t    mtime;     // Modification time
        time_t    ctime;     // Create time
        char     *Group;     // -> Group name
+       char     *User;      // -> User name
        char     *SLink;     // -> Symlink contents
        char      Otype;     // 'd' | 'f' | 'l' | 'p' | '?'
        char      Xtype;     // 'x' | 0
 
-       bbcp_FileInfo() : Group(0), SLink(0), Otype('?'), Xtype(0) {}
+       bbcp_FileInfo() : Group(0), User(0), SLink(0), Otype('?'), Xtype(0) {}
       ~bbcp_FileInfo() {if (Group) free(Group);
+                        if (User) free(User);
                         if (SLink) free(SLink);
                        }
 };

--- a/src/bbcp_FileSystem.h
+++ b/src/bbcp_FileSystem.h
@@ -121,6 +121,10 @@ virtual int        RM(const char *path)=0;
 //
 virtual int        setGroup(const char *path, const char *Group)=0;
 
+// Set the user information for a file & return 0. Returns -errno upon error.
+//
+virtual int        setUser(const char *path, const char *User)=0;
+
 // Set the mode on a file & return 0. Returns -errno upon error.
 //
 virtual int        setMode(const char *path, mode_t mode)=0;

--- a/src/bbcp_MD5.C
+++ b/src/bbcp_MD5.C
@@ -167,7 +167,7 @@ void bbcp_MD5::MD5Final(unsigned char digest[16], struct MD5Context *ctx)
  */
 void bbcp_MD5::MD5Transform(uint32 buf[4], uint32 const in[16])
 {
-    register uint32 a, b, c, d;
+    uint32 a, b, c, d;
 
     a = buf[0];
     b = buf[1];

--- a/src/bbcp_MD5_openssl.C
+++ b/src/bbcp_MD5_openssl.C
@@ -96,7 +96,7 @@ void bbcp_MD5_openssl::MD5Final(unsigned char digest[16], MD5_CTX *ctx)
  */
 void bbcp_MD5_openssl::MD5Transform(uint32 buf[4], uint32 const in[16])
 {
-    register uint32 a, b, c, d;
+    uint32 a, b, c, d;
 
     a = buf[0];
     b = buf[1];

--- a/src/bbcp_MD5_openssl.h
+++ b/src/bbcp_MD5_openssl.h
@@ -32,6 +32,10 @@
 
 typedef unsigned int uint32;
 
+// OpenSSL 3.0 이상에서 MD5 함수 사용을 위한 매크로
+#define OPENSSL_API_COMPAT 0x10100000L
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 /******************************************************************************/
 /*                  M D 5 C o n t e x t   S t r u c t u r e                   */
 /******************************************************************************/

--- a/src/bbcp_Pthread.h
+++ b/src/bbcp_Pthread.h
@@ -35,6 +35,13 @@
 
 #include <exception>
 
+// C++11 이상에서는 noexcept를, 이전 버전에서는 throw()를 사용
+#if __cplusplus >= 201103L
+#define BBCP_NOEXCEPT noexcept
+#else
+#define BBCP_NOEXCEPT throw()
+#endif
+
 class bbcp_CondVar
 {
 public:
@@ -62,7 +69,8 @@ inline void  UnLock()         {pthread_mutex_unlock(&cmut);}
                      pthread_mutex_init(&cmut, NULL);
                      relMutex = relm;
                     }
-     ~bbcp_CondVar() {pthread_cond_destroy(&cvar);
+     ~bbcp_CondVar() BBCP_NOEXCEPT {
+                      pthread_cond_destroy(&cvar);
                       pthread_mutex_destroy(&cmut);
                      }
 private:
@@ -86,7 +94,7 @@ inline void   Lock() {pthread_mutex_lock(&cs);}
 inline void UnLock() {pthread_mutex_unlock(&cs);}
 
         bbcp_Mutex() {pthread_mutex_init(&cs, NULL);}
-       ~bbcp_Mutex() {pthread_mutex_destroy(&cs);}
+       ~bbcp_Mutex() BBCP_NOEXCEPT {pthread_mutex_destroy(&cs);}
 
 private:
 
@@ -103,7 +111,7 @@ void    UnLock() {if (monMutex) {monMutex->UnLock(); monMutex = 0;}}
                      {theMutex->Lock();}
         bbcp_MutexMon(bbcp_Mutex &theMutex) : monMutex(&theMutex)
                      {theMutex. Lock();}
-       ~bbcp_MutexMon() {if (monMutex) {monMutex->UnLock(); monMutex = 0;}}
+       ~bbcp_MutexMon() BBCP_NOEXCEPT {if (monMutex) {monMutex->UnLock(); monMutex = 0;}}
 
 private:
 bbcp_Mutex *monMutex;
@@ -121,7 +129,7 @@ public:
        void Wait();
 
   bbcp_Semaphore(int semval=1) : semVar(0), semVal(semval), semWait(0) {}
- ~bbcp_Semaphore() {}
+ ~bbcp_Semaphore() BBCP_NOEXCEPT {}
 
 private:
 
@@ -158,8 +166,8 @@ inline void Wait() {int rc;
   bbcp_Semaphore(int semval=1) {if (sem_init(&h_semaphore, 0, semval))
                                    {throw "sem_init() failed", errno;}
                                }
- ~bbcp_Semaphore() throw(std::exception) {if (sem_destroy(&h_semaphore))
-                       {throw "sem_destroy() failed", errno;}
+ ~bbcp_Semaphore() BBCP_NOEXCEPT {
+                       sem_destroy(&h_semaphore);
                    }
 
 private:

--- a/src/bbcp_System.C
+++ b/src/bbcp_System.C
@@ -132,6 +132,45 @@ char *bbcp_System::getGNM(gid_t gid)
 }
  
 /******************************************************************************/
+/*                                g e t U I D                                 */
+/******************************************************************************/
+
+uid_t bbcp_System::getUID(const char *user)
+{
+   uid_t uid;
+   struct passwd *pp;
+
+// Convert the user name to a uid
+//
+   Glookup.Lock();
+   if ((pp = getpwnam(user))) uid = pp->pw_uid;
+      else uid = (uid_t)-1;
+   Glookup.UnLock();
+   return uid;
+}
+
+/******************************************************************************/
+/*                                g e t U N M                                 */
+/******************************************************************************/
+
+char *bbcp_System::getUNM(uid_t uid)
+{
+   char *unmp;
+   struct passwd *pp;
+
+// Get the user name
+//
+   Glookup.Lock();
+   if ((pp = getpwuid(uid))) unmp = pp->pw_name;
+      else unmp = (char *)"nobody";
+   Glookup.UnLock();
+
+// Return a copy of the user name
+//
+   return strdup(unmp);
+}
+ 
+/******************************************************************************/
 /*                            g e t H o m e D i r                             */
 /******************************************************************************/
   

--- a/src/bbcp_System.h
+++ b/src/bbcp_System.h
@@ -47,6 +47,14 @@ gid_t      getGID(const char *group);
 //
 char      *getGNM(gid_t gid);
 
+// Convert a user name to a UID return -1 if failed.
+//
+uid_t      getUID(const char *user);
+
+// Convert a UID to a user name return "nobody" if failed.
+//
+char      *getUNM(uid_t uid);
+
 // Get the home directory
 //
 char      *getHomeDir();

--- a/src/bbcp_Version.C
+++ b/src/bbcp_Version.C
@@ -51,7 +51,7 @@ bbcp_Version::bbcp_Version()
 Copyright = "(c) 2002-2017 by the Board of Trustees of the Leland Stanford, Jr., University";
 Author    = "Andrew Hanushevsky";
 //                    12345678901
-Version   = "Version: 17.12.00.00.0";
+Version   = "Version: 17.13.00.00.0";
 //           0123456789
 VData     = Version+9;
 };


### PR DESCRIPTION
## Summary by Sourcery

Adds support for preserving user ownership during file transfers, updates the version number, and fixes minor code issues.

Enhancements:
- Adds user name preservation during file transfers using the -p option.
- Updates the SSH execution commands to use 'fmbbcp' instead of 'bbcp'